### PR TITLE
Fix for close button not changing the app bar state

### DIFF
--- a/src/MicroEngineer/MicroEngineerPlugin.cs
+++ b/src/MicroEngineer/MicroEngineerPlugin.cs
@@ -31,7 +31,6 @@ public class MicroEngineerPlugin : BaseSpaceWarpPlugin
     // AppBar button IDs
     internal const string ToolbarFlightButtonID = "BTN-MicroEngineerFlight";
     internal const string ToolbarOabButtonID = "BTN-MicroEngineerOAB";
-    internal const string ToolbarKscButtonID = "BTN-MicroEngineerKSC";
     
     public Coroutine MainUpdateLoop;
 

--- a/src/MicroEngineer/UI/MainGuiController.cs
+++ b/src/MicroEngineer/UI/MainGuiController.cs
@@ -78,7 +78,7 @@ namespace MicroEngineer.UI
 
             Utility.SaveLayout();
             FlightSceneController.Instance.ShowGui = false;
-            GameObject.Find("BTN-MicroEngineerBtn")?.GetComponent<UIValue_WriteBool_Toggle>()?.SetValue(false);
+            GameObject.Find(MicroEngineerPlugin.ToolbarFlightButtonID)!.GetComponent<UIValue_WriteBool_Toggle>()!.SetValue(false);
         }
 
         private void OnMinimizeButton(ClickEvent evt)

--- a/src/MicroEngineer/UI/StageInfoOABController.cs
+++ b/src/MicroEngineer/UI/StageInfoOABController.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx.Logging;
+using KSP.UI.Binding;
 using MicroEngineer.Entries;
 using MicroEngineer.Managers;
 using MicroEngineer.Utilities;
@@ -207,7 +208,8 @@ namespace MicroEngineer.UI
             StageInfoOABWindow.IsEditorActive = false;
             Utility.SaveLayout();
             OABSceneController.Instance.ShowGui = false;
-        }
+			GameObject.Find(MicroEngineerPlugin.ToolbarOabButtonID)!.GetComponent<UIValue_WriteBool_Toggle>()!.SetValue(false);
+		}
         
         public void InitializeControl(BaseEntryControl control, BaseEntry entry, bool subscribeToValueChanges = true)
         {

--- a/src/MicroEngineer/UI/StageInfoOABController.cs
+++ b/src/MicroEngineer/UI/StageInfoOABController.cs
@@ -208,8 +208,8 @@ namespace MicroEngineer.UI
             StageInfoOABWindow.IsEditorActive = false;
             Utility.SaveLayout();
             OABSceneController.Instance.ShowGui = false;
-			GameObject.Find(MicroEngineerPlugin.ToolbarOabButtonID)!.GetComponent<UIValue_WriteBool_Toggle>()!.SetValue(false);
-		}
+            GameObject.Find(MicroEngineerPlugin.ToolbarOabButtonID)!.GetComponent<UIValue_WriteBool_Toggle>()!.SetValue(false);
+        }
         
         public void InitializeControl(BaseEntryControl control, BaseEntry entry, bool subscribeToValueChanges = true)
         {


### PR DESCRIPTION
Use were using a magic literal for the in-flight button, and didn't do anything when closing the menu in VAB (OAB? Orbital AB?).

Other than that, minor changes:
1. Removed `ToolbarKscButtonID` - you don't have that.
2. Changed `?` to `!` when getting the app bar component. It's better to at least have an error in Alt+C. And since this is at the end of callback, and UI callbacks are always executed in a `try-catch` block - this doesn't change the logic.