### PR TITLE
Add pull request trigger to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
I recently figured out with `munix` that the `push` trigger created GitHub Action in the repo that had the push.
So if the commit is pushed to my fork, no Action is created in this repo and so my PR doesn't have the "Checks successful" badge:
https://discord.com/channels/1078696971088433153/1078841771771056280/1215255763518230528

Btw, this is already fixed in the latest version of the template.
And I see you somehow already [updated the template](https://github.com/Falki-git/MicroEngineer/tree/new-template-version) before, right?
Mind sharing your process for this kind of update? I've set up [this for myself](https://github.com/SunSerega/KSP2-SASed-Warp/blob/main/.github/workflows/update-template.yml), but now I'm thinking if there was an easier route...