### PR TITLE
Fix science region NRE and reflection lookup

### DIFF
--- a/Assets/MicroEngineer/Code/Entries/BodyEntries.cs
+++ b/Assets/MicroEngineer/Code/Entries/BodyEntries.cs
@@ -92,7 +92,7 @@ namespace MicroEngineer.Entries
 
         public override void RefreshData()
         {
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName)?.SituationData
                 ?.AtmosphereMaxAltutude / 1000;
         }
 
@@ -118,7 +118,7 @@ namespace MicroEngineer.Entries
 
         public override void RefreshData()
         {
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName)?.SituationData
                 ?.LowOrbitMaxAltutude / 1000;
         }
 
@@ -144,7 +144,7 @@ namespace MicroEngineer.Entries
 
         public override void RefreshData()
         {
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.mainBody.bodyName)?.SituationData
                 ?.HighOrbitMaxAltitude / 1000;
         }
 

--- a/Assets/MicroEngineer/Code/Entries/TargetEntries.cs
+++ b/Assets/MicroEngineer/Code/Entries/TargetEntries.cs
@@ -877,7 +877,7 @@ namespace MicroEngineer.Entries
                 return;
             }
 
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName)?.SituationData
                 ?.AtmosphereMaxAltutude / 1000;
         }
 
@@ -910,7 +910,7 @@ namespace MicroEngineer.Entries
                 return;
             }
 
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName)?.SituationData
                 ?.LowOrbitMaxAltutude / 1000;
         }
 
@@ -943,7 +943,7 @@ namespace MicroEngineer.Entries
                 return;
             }
 
-            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName).SituationData
+            EntryValue = Utility.GetBodyScienceRegion(Utility.ActiveVessel.TargetObject.DisplayName)?.SituationData
                 ?.HighOrbitMaxAltitude / 1000;
         }
 

--- a/Assets/MicroEngineer/Code/Utilities/Utility.cs
+++ b/Assets/MicroEngineer/Code/Utilities/Utility.cs
@@ -320,7 +320,8 @@ namespace MicroEngineer.Utilities
 
         public static CelestialBodyScienceRegionsData GetBodyScienceRegion(string body)
         {
-            return !ScienceRegions.ContainsKey(body) ? null : ScienceRegions[body];
+            var scienceRegions = ScienceRegions;
+            return scienceRegions == null || !scienceRegions.ContainsKey(body) ? null : scienceRegions[body];
         }
 
         /*

--- a/Assets/MicroEngineer/Code/Utilities/Utility.cs
+++ b/Assets/MicroEngineer/Code/Utilities/Utility.cs
@@ -305,7 +305,7 @@ namespace MicroEngineer.Utilities
             Type providerType = scienceRegionsProvider.GetType();
 
             FieldInfo cbToScienceRegionsField =
-                providerType.GetField("_cbToScienceRegions");
+                providerType.GetField("_cbToScienceRegions", BindingFlags.NonPublic | BindingFlags.Instance);
 
             if (cbToScienceRegionsField == null)
                 return null;

--- a/Assets/MicroEngineer/swinfo.asset
+++ b/Assets/MicroEngineer/swinfo.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   name: Micro Engineer
   author: Falki
   description: Get in-flight and VAB information about your current vessel
-  version: 1.8.3
+  version: 1.8.4
   versionCheck: https://github.com/Falki-git/MicroEngineer/blob/redux/master/Assets/MicroEngineer/swinfo.json
   minKsp2Version: 0.2.8.3
   maxKsp2Version: '*'

--- a/Assets/MicroEngineer/swinfo.json
+++ b/Assets/MicroEngineer/swinfo.json
@@ -5,7 +5,7 @@
   "author": "Falki",
   "description": "Get in-flight and VAB information about your current vessel",
   "source": "https://github.com/Falki-git/MicroEngineer/tree/redux/master",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "version_check": "https://github.com/Falki-git/MicroEngineer/blob/redux/master/Assets/MicroEngineer/swinfo.json",
   "ksp2_version": {
     "min": "0.2.8.3",


### PR DESCRIPTION
## Summary
- `Utility.GetBodyScienceRegion()` called `ContainsKey` on the `ScienceRegions` dictionary without a null check, and the null case was never cached, so it threw a fresh `NullReferenceException` on every `DoFlightUpdate` tick whenever the game's science regions provider wasn't available. Also guarded the `Body*`/`Target_Body*` entry call sites (`?.SituationData`) since `GetBodyScienceRegion` can legitimately return null.
- Root cause of the Atmosphere/Low Orbit/High Orbit Altitude entries showing `-`: `GetScienceRegions()` looked up the private `_cbToScienceRegions` field via `Type.GetField("_cbToScienceRegions")` with no `BindingFlags`, which only searches public members. Since the field is private and the assembly isn't publicized, the lookup always returned null. Fixed by passing `BindingFlags.NonPublic | BindingFlags.Instance`.

## Test plan
- [ ] Build for Editor and confirm no more NRE spam in `Player.log` during flight
- [ ] Confirm Atmosphere/Low Orbit/High Orbit Altitude entries populate correctly for the current body/target