### PR TITLE
Fix unreliable click registration on EditWindows entries

### DIFF
--- a/Assets/MicroEngineer/Code/UI/EditWindowsController.cs
+++ b/Assets/MicroEngineer/Code/UI/EditWindowsController.cs
@@ -118,12 +118,12 @@ namespace MicroEngineer.UI
             {
                 var control = new EditWindowsItemControl(e.Name, true);
                 var textField = control.Q<TextField>();
-                textField.RegisterCallback<MouseDownEvent>(evt => OnAvailableEntryClicked(evt, control, e));
+                textField.RegisterCallback<PointerDownEvent>(evt => OnAvailableEntryClicked(evt, control, e), TrickleDown.TrickleDown);
                 AvailableScrollView.Add(control);
             }
         }
 
-        private void OnAvailableEntryClicked(MouseDownEvent evt, EditWindowsItemControl control, BaseEntry entry)
+        private void OnAvailableEntryClicked(PointerDownEvent evt, EditWindowsItemControl control, BaseEntry entry)
         {
             if (evt.button == (int)MouseButton.LeftMouse)
             {
@@ -195,7 +195,7 @@ namespace MicroEngineer.UI
                 incDecimal.RegisterCallback<PointerUpEvent>(_ => IncreaseDecimalDigits(e, incDecimal, decDecimal));
                 decDecimal.RegisterCallback<PointerUpEvent>(_ => DecreaseDecimalDigits(e, incDecimal, decDecimal));
                 CheckIfDecimalButtonsShouldBeEnabled(e, incDecimal, decDecimal);
-                textField.RegisterCallback<MouseDownEvent>(evt => OnInstalledEntryClicked(evt, control, e));
+                textField.RegisterCallback<PointerDownEvent>(evt => OnInstalledEntryClicked(evt, control, e), TrickleDown.TrickleDown);
                 textField.RegisterValueChangedCallback(evt => RenameEntry(evt, e));
                 textField.DisableGameInputOnFocus();
                 _installedControls.Add((control, e));
@@ -203,7 +203,7 @@ namespace MicroEngineer.UI
             }
         }
 
-        private void OnInstalledEntryClicked(MouseDownEvent evt, EditWindowsItemControl control, BaseEntry entry)
+        private void OnInstalledEntryClicked(PointerDownEvent evt, EditWindowsItemControl control, BaseEntry entry)
         {
             if (evt.button == (int)MouseButton.LeftMouse)
             {

--- a/Assets/MicroEngineer/UI/Flight.uss
+++ b/Assets/MicroEngineer/UI/Flight.uss
@@ -62,7 +62,7 @@
 }
 
 .maingui-settings-button {
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/icon.png?fileID=2800000&guid=ccf72edfd194e9643acc40cfba3461ce&type=3#icon');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/icon.png?fileID=2800000&guid=ccf72edfd194e9643acc40cfba3461ce&type=3#icon");
     -unity-background-scale-mode: scale-to-fit;
     width: 20px;
     height: 20px;
@@ -194,7 +194,7 @@
 .settings-button__background {
     width: 100%;
     height: 100%;
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/k2dt_gear.png?fileID=2800000&guid=307def24b939c85478cc4129941b0ddc&type=3#k2dt_gear');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/k2dt_gear.png?fileID=2800000&guid=307def24b939c85478cc4129941b0ddc&type=3#k2dt_gear");
     -unity-background-image-tint-color: rgb(192, 199, 213);
 }
 
@@ -224,7 +224,7 @@
 .popout-button__background {
     width: 100%;
     height: 100%;
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/falki_popout.png?fileID=2800000&guid=7b5d9d2d71678694f8f5a8c1f36a7769&type=3#falki_popout');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/falki_popout.png?fileID=2800000&guid=7b5d9d2d71678694f8f5a8c1f36a7769&type=3#falki_popout");
     -unity-background-image-tint-color: rgb(192, 199, 213);
 }
 
@@ -254,7 +254,7 @@
 .close-button__background {
     width: 100%;
     height: 100%;
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/k2d2_cross.png?fileID=2800000&guid=db20fccdba42f464a90ffab0dc4cd628&type=3#k2d2_cross');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/k2d2_cross.png?fileID=2800000&guid=db20fccdba42f464a90ffab0dc4cd628&type=3#k2d2_cross");
     -unity-background-image-tint-color: rgb(192, 199, 213);
     -unity-background-scale-mode: scale-to-fit;
 }
@@ -286,7 +286,7 @@
 .minimize-button__background {
     width: 100%;
     height: 100%;
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/minus.png?fileID=2800000&guid=a2b5fcf88dc9dd24395a151854fcbdf0&type=3#minus');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/minus.png?fileID=2800000&guid=a2b5fcf88dc9dd24395a151854fcbdf0&type=3#minus");
     -unity-background-image-tint-color: rgb(192, 199, 213);
     -unity-background-scale-mode: scale-to-fit;
 }
@@ -972,7 +972,7 @@
 }
 
 .edit-windows__entry__increase-decimal-background {
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/increase-decimal-19.png?fileID=21300000&guid=e8eb722b8364c604f8bb57fe1fbb2c7c&type=3#increase-decimal-19');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/increase-decimal-19.png?fileID=21300000&guid=e8eb722b8364c604f8bb57fe1fbb2c7c&type=3#increase-decimal-19");
     width: 100%;
     height: 100%;
 }
@@ -1007,7 +1007,7 @@
 .edit-windows__entry__decrease-decimal-background {
     width: 100%;
     height: 100%;
-    background-image: url('project://database/Assets/MicroEngineer/UI/Images/decrease-decimal-19.png?fileID=21300000&guid=76b60bc40118807459036d0b8c4b9710&type=3#decrease-decimal-19');
+    background-image: url("project://database/Assets/MicroEngineer/UI/Images/decrease-decimal-19.png?fileID=21300000&guid=76b60bc40118807459036d0b8c4b9710&type=3#decrease-decimal-19");
 }
 
 .edit-windows__entry__decrease-decimal-background:disabled {
@@ -1093,4 +1093,9 @@
 
 .unity-popup-field__input {
     height: 20px;
+}
+
+.unity-base-popup-field__arrow {
+    left: -10px;
+    top: -1px;
 }

--- a/Assets/MicroEngineer/UI/OAB.uss
+++ b/Assets/MicroEngineer/UI/OAB.uss
@@ -674,6 +674,11 @@
     width: 100%;
 }
 
+.unity-base-popup-field__arrow {
+    left: -10px;
+    background-size: 70% 70%;
+}
+
 .unity-popup-field {
     font-size: var(--font-size-small-3);
 }


### PR DESCRIPTION
## Summary
- Clicking entries in the EditWindows window (both Available and Installed lists) required many repeated clicks to register a selection, a regression from the Redux Unity/UITK upgrade.
  - Root cause: `TextField`'s internal `TextElement` hardcodes `selection.isSelectable = true` and its built-in `TextSelectingManipulator` captures the pointer and calls `StopPropagation()` on `PointerDown`/`PointerUp` events that land on the text glyphs, swallowing the click before it bubbles up to our handler on the outer `TextField`. Confirmed by decompiling `UnityEngine.UIElementsModule.dll` for Unity `6000.4.1f1`.
  - Fix: register the entry click handlers on the `TrickleDown` (capture) phase instead of the bubble phase, so our handler runs on the way down before the inner `TextElement` gets a chance to consume the event.
- Fix dropdown arrow position: corrects `.unity-base-popup-field__arrow` positioning/sizing in `Flight.uss` and `OAB.uss` (also normalizes `url(...)` quoting to double quotes for consistency).

## Test plan
- [ ] Rebuild the mod via ThunderKit and load into KSP2
- [ ] Open the EditWindows window and click entries in the Available list — confirm selection registers on the first click
- [ ] Click entries in the Installed list — confirm selection registers on the first click and renaming/decimal controls still work
- [ ] Verify double-click-to-add / double-click-to-remove still work as before
- [ ] Verify dropdown arrows (Flight/OAB windows) render in the correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)